### PR TITLE
Reference vectored IO system calls

### DIFF
--- a/_posts/2016-10-13-linux-aio.md
+++ b/_posts/2016-10-13-linux-aio.md
@@ -212,11 +212,11 @@ enum {
 
 * IOCB_CMD_PREADV
 :  vectored positioned read, sometimes called "scattered input";
-   corresponds to `pread()` system call.
+   corresponds to `preadv()` system call.
 
 * IOCB_CMD_PWRITEV
 :  vectored positioned write, sometimes called "gathered output";
-   corresponds to `pwrite()` system call.
+   corresponds to `pwritev()` system call.
 
 * IOCB_CMD_NOOP
 :   defined in the header file, but is not used anywhere else in the kernel.


### PR DESCRIPTION
The documentation for the vectored AIO commands references the normal
instead of the vectored system calls.